### PR TITLE
fixes #2 with appsettings.json

### DIFF
--- a/CertificationsDevelopment/Startup.cs
+++ b/CertificationsDevelopment/Startup.cs
@@ -26,18 +26,17 @@ namespace CertificationsDevelopment {
 			services.AddScoped<IUserProfileData, SqlUserProfileData>();
 
 			services.AddTransient<IEmailSender, EmailSender>();
-			//services.Configure<AuthMessageSenderOptions>(Configuration);
+			services.Configure<AuthMessageSenderOptions>(Configuration.GetSection(nameof(AuthMessageSenderOptions)));
 
-			services.Configure<IdentityOptions>(options => {
+			services.Configure<IdentityOptions>(options =>
+			{
 				options.SignIn.RequireConfirmedAccount = false;
 				options.SignIn.RequireConfirmedEmail = false;
 				options.SignIn.RequireConfirmedPhoneNumber = false;
 
 				options.Password.RequireNonAlphanumeric = false;
-				
+
 			});
-
-
 
 			services.AddDbContext<ApplicationDbContext>(options =>
 				options.UseSqlServer(


### PR DESCRIPTION
### appsettings.json
`"AuthMessageSenderOptions": {
		"SendGridUser": "",
		"SendGridKey": ""
}`

We can get dose over Configuration.GetSection and parse the Class name as key.
![image](https://user-images.githubusercontent.com/38018790/79699087-65e92800-828d-11ea-8338-48c6cef610f1.png)

It's done like the approach of the connection string for the Sql server.